### PR TITLE
Allow logging in with full MIT email

### DIFF
--- a/src/js/krb.js
+++ b/src/js/krb.js
@@ -8,6 +8,9 @@ import krb from'./krb_proto.js';
 /** @const */ krb.allowed_client_realms = [
     "ATHENA.MIT.EDU",
 ]
+/** @const */ krb.realm_aliases = {
+    'mit.edu': 'ATHENA.MIT.EDU',
+};
 /** @const */ krb.supportedEnctypes = [
     kcrypto.enctype.aes256_cts_hmac_sha1_96,
     kcrypto.enctype.aes128_cts_hmac_sha1_96
@@ -86,6 +89,10 @@ krb.Principal.fromString = function(str) {
         components.push(component);
         // If no realm, use the default.
         component = krb.realm;
+    }
+    // Handle aliases (e.g. @mit.edu to @ATHENA.MIT.EDu)
+    if (krb.realm_aliases[component]) {
+        component = krb.realm_aliases[component];
     }
     return new krb.Principal({
         nameType: krb.KRB_NT_PRINCIPAL,

--- a/test/spec/test-krb.js
+++ b/test/spec/test-krb.js
@@ -47,6 +47,20 @@ describe("kdc", function() {
     assert.equal(principal.nameToString(), "davidben");
   });
 
+  it("should support aliases, i.e. converting email to kerb", function() {
+    var principal = krb.Principal.fromString("jflorey@mit.edu");
+    // @mit.edu is defined as an alias for @ATHENA.MIT.EDU,
+    //   so everything should work the same
+    assert.equal(principal.realm, "ATHENA.MIT.EDU");
+    assert.equal(principal.principalName.nameType, krb.KRB_NT_PRINCIPAL);
+    assert.equal(principal.principalName.nameType, krb.KRB_NT_PRINCIPAL);
+    assert.ok(principal.principalName.nameString.length === 1 &&
+              principal.principalName.nameString[0] === "jflorey");
+    assert.equal(principal.toString(), "jflorey@ATHENA.MIT.EDU");
+    assert.equal(principal.toStringShort(), "jflorey");
+    assert.equal(principal.nameToString(), "jflorey");
+  });
+
   it("should throw on malformed principals", function() {
     assert.throws(function() { krb.Principal.fromString("davidben\\"); });
     assert.throws(function() { krb.Principal.fromString("davidben@FOO@BAR"); });


### PR DESCRIPTION
Someone trying to use a Webathena-using application complained that their "MIT email wasn't working" with

> When I try to login with my Kerberos information, it's saying 'Realm mit.edu not supported!'. 

This pull request allows using @mit.edu addresses as if they were @ATHENA.MIT.EDU kerberi.